### PR TITLE
Hotfix foutive bedaming "Registreer -> Log-in"

### DIFF
--- a/html/login.html
+++ b/html/login.html
@@ -34,8 +34,8 @@
             <input type="text" id="paswoord" placeholder="Paswoord"/>
         </section>
         <section>
-            <label for="submit">Registreer</label>
-            <input type="submit" id="submit" value="Registreer"/>
+            <label for="submit">Log-in</label>
+            <input type="submit" id="submit" value="Log-in"/>
         </section>
     </form>
 </main>


### PR DESCRIPTION
Label (37) als Input (38) hadden beiden de foute benaming gekregen.